### PR TITLE
Add iOS Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 .pub-cache/
 .pub/
 /build/
+pubspec.lock  # Except for application packages
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -107,28 +107,32 @@ class PhoneDependentContainer extends StatelessWidget {
         return Center(
           child: FutureBuilder<AndroidDeviceInfo>(
             future: deviceInfo.androidInfo,
-            builder: (context, snapshot) => Visibility(
-              visible: snapshot.hasData,
-              child: builder(
-                context,
-                snapshot.data.model,
-                snapshot.data,
-              ),
-            ),
+            builder: (context, snapshot) => !snapshot.hasData
+                ? Container()
+                : Visibility(
+                    visible: snapshot.hasData,
+                    child: builder(
+                      context,
+                      snapshot.data.model,
+                      snapshot.data,
+                    ),
+                  ),
           ),
         );
       case TargetPlatform.iOS:
         return Center(
           child: FutureBuilder<IosDeviceInfo>(
             future: deviceInfo.iosInfo,
-            builder: (context, snapshot) => Visibility(
-              visible: snapshot.hasData,
-              child: builder(
-                context,
-                snapshot.data.model,
-                snapshot.data,
-              ),
-            ),
+            builder: (context, snapshot) => !snapshot.hasData
+                ? Container()
+                : Visibility(
+                    visible: snapshot.hasData,
+                    child: builder(
+                      context,
+                      snapshot.data.model,
+                      snapshot.data,
+                    ),
+                  ),
           ),
         );
       default:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,7 +25,74 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) => Scaffold(
         backgroundColor: Colors.grey,
         body: PhoneDependentContainer(
-          builder: (context, model, deviceInfo, debugableInfo) => InkWell(
+          androidBuilder: (context, model, deviceInfo, debugableInfo) =>
+              InkWell(
+            onTap: () => print('All Info: $debugableInfo, '),
+            child: Container(
+              child: SizedBox(
+                height: 160.0,
+                child: ListView(
+                  scrollDirection: Axis.horizontal,
+                  children: <Widget>[
+                    Container(
+                      width: 160,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: colorForModel(
+                          model,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      width: 160,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: colorForModel(
+                          model,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      width: 160,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: colorForModel(
+                          model,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      width: 160,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: colorForModel(
+                          model,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      width: 160,
+                      decoration: BoxDecoration(
+                        borderRadius: BorderRadius.circular(30),
+                        color: colorForModel(
+                          model,
+                        ),
+                      ),
+                    ),
+                    Container(
+                      width: 160.0,
+                      color: Colors.grey,
+                      child: Center(
+                        child:
+                            Text('manufacturer: ${deviceInfo.manufacturer}, '),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          iOSBuilder: (context, model, deviceInfo, debugableInfo) => InkWell(
             onTap: () => print('All Info: $debugableInfo, '),
             child: Container(
               child: SizedBox(
@@ -95,10 +162,17 @@ class _HomeState extends State<Home> {
 }
 
 class PhoneDependentContainer extends StatelessWidget {
-  final Widget Function(BuildContext, String, dynamic, Map) builder;
+  final Widget Function(BuildContext, String, AndroidDeviceInfo, Map)
+  androidBuilder;
+  final Widget Function(BuildContext, String, IosDeviceInfo, Map) iOSBuilder;
   final DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
 
-  PhoneDependentContainer({Key key, @required this.builder}) : super(key: key);
+  PhoneDependentContainer({
+    Key key,
+    @required this.iOSBuilder,
+    @required this.androidBuilder,
+  }) : super(key: key);
+
   Map<String, dynamic> _readAndroidBuildData(AndroidDeviceInfo build) {
     return <String, dynamic>{
       'version.securityPatch': build.version.securityPatch,
@@ -159,14 +233,14 @@ class PhoneDependentContainer extends StatelessWidget {
                 ? Container()
                 : Visibility(
                     visible: snapshot.hasData,
-                    child: builder(
-                      context,
-                      snapshot.data.model,
-                      snapshot.data,
-                      _readAndroidBuildData(
-                        snapshot.data,
-                      ),
-                    ),
+              child: androidBuilder(
+                context,
+                snapshot.data.model,
+                snapshot.data,
+                _readAndroidBuildData(
+                  snapshot.data,
+                ),
+              ),
                   ),
           ),
         );
@@ -178,14 +252,14 @@ class PhoneDependentContainer extends StatelessWidget {
                 ? Container()
                 : Visibility(
                     visible: snapshot.hasData,
-                    child: builder(
-                      context,
-                      snapshot.data.model,
-                      snapshot.data,
-                      _readIosDeviceInfo(
-                        snapshot.data,
-                      ),
-                    ),
+              child: iOSBuilder(
+                context,
+                snapshot.data.model,
+                snapshot.data,
+                _readIosDeviceInfo(
+                  snapshot.data,
+                ),
+              ),
                   ),
           ),
         );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,18 +1,9 @@
-import 'package:babyshaarkapp/Container.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_local_notifications/flutter_local_notifications.dart';
-import 'package:notification_banner/notification_alert.dart';
-import 'notification_banner.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'dart:async';
-import 'package:flutter/services.dart';
-import 'package:intl/intl.dart';
 import 'package:device_info/device_info.dart';
-import 'package:async/async.dart';
+import 'package:flutter/material.dart';
 
 void main() => runApp(MaterialApp(
-  home: Home(),
-));
+      home: Home(),
+    ));
 
 class Home extends StatefulWidget {
   @override
@@ -20,9 +11,6 @@ class Home extends StatefulWidget {
 }
 
 class _HomeState extends State<Home> {
-  DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
-  AndroidDeviceInfo androidInfo;
-
   Color colorForModel(String model) {
     if (model == "sdk_gphone_x86") {
       return Colors.amber;
@@ -35,14 +23,10 @@ class _HomeState extends State<Home> {
 
   @override
   Widget build(BuildContext context) => Scaffold(
-    backgroundColor: Colors.grey,
-    body: Center(
-      child: FutureBuilder<AndroidDeviceInfo>(
-        future: deviceInfo.androidInfo,
-        builder: (context, snapshot) => Visibility(
-          visible: snapshot.hasData,
-          child: InkWell(
-            onTap: () => print('Manufacturer: ${snapshot.data.device}, '),
+        backgroundColor: Colors.grey,
+        body: PhoneDependentContainer(
+          builder: (context, model, deviceInfo) => InkWell(
+            onTap: () => print('All Info: $deviceInfo, '),
             child: Container(
               child: SizedBox(
                 height: 160.0,
@@ -54,7 +38,7 @@ class _HomeState extends State<Home> {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: colorForModel(
-                          snapshot.data.model,
+                          model,
                         ),
                       ),
                     ),
@@ -63,7 +47,7 @@ class _HomeState extends State<Home> {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: colorForModel(
-                          snapshot.data.model,
+                          model,
                         ),
                       ),
                     ),
@@ -72,7 +56,7 @@ class _HomeState extends State<Home> {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: colorForModel(
-                          snapshot.data.model,
+                          model,
                         ),
                       ),
                     ),
@@ -81,7 +65,7 @@ class _HomeState extends State<Home> {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: colorForModel(
-                          snapshot.data.model,
+                          model,
                         ),
                       ),
                     ),
@@ -90,7 +74,7 @@ class _HomeState extends State<Home> {
                       decoration: BoxDecoration(
                         borderRadius: BorderRadius.circular(30),
                         color: colorForModel(
-                          snapshot.data.model,
+                          model,
                         ),
                       ),
                     ),
@@ -98,7 +82,7 @@ class _HomeState extends State<Home> {
                       width: 160.0,
                       color: Colors.grey,
                       child: Center(
-                        child: Text('model: ${snapshot.data.model}, '),
+                        child: Text('model: ${model}, '),
                       ),
                     ),
                   ],
@@ -107,7 +91,48 @@ class _HomeState extends State<Home> {
             ),
           ),
         ),
-      ),
-    ),
-  );
+      );
+}
+
+class PhoneDependentContainer extends StatelessWidget {
+  final Widget Function(BuildContext, String, dynamic) builder;
+  final DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
+
+  PhoneDependentContainer({Key key, @required this.builder}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    switch (Theme.of(context).platform) {
+      case TargetPlatform.android:
+        return Center(
+          child: FutureBuilder<AndroidDeviceInfo>(
+            future: deviceInfo.androidInfo,
+            builder: (context, snapshot) => Visibility(
+              visible: snapshot.hasData,
+              child: builder(
+                context,
+                snapshot.data.model,
+                snapshot.data,
+              ),
+            ),
+          ),
+        );
+      case TargetPlatform.iOS:
+        return Center(
+          child: FutureBuilder<IosDeviceInfo>(
+            future: deviceInfo.iosInfo,
+            builder: (context, snapshot) => Visibility(
+              visible: snapshot.hasData,
+              child: builder(
+                context,
+                snapshot.data.model,
+                snapshot.data,
+              ),
+            ),
+          ),
+        );
+      default:
+        return Container();
+    }
+  }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,8 +25,8 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) => Scaffold(
         backgroundColor: Colors.grey,
         body: PhoneDependentContainer(
-          builder: (context, model, deviceInfo) => InkWell(
-            onTap: () => print('All Info: $deviceInfo, '),
+          builder: (context, model, deviceInfo, debugableInfo) => InkWell(
+            onTap: () => print('All Info: $debugableInfo, '),
             child: Container(
               child: SizedBox(
                 height: 160.0,
@@ -95,10 +95,58 @@ class _HomeState extends State<Home> {
 }
 
 class PhoneDependentContainer extends StatelessWidget {
-  final Widget Function(BuildContext, String, dynamic) builder;
+  final Widget Function(BuildContext, String, dynamic, Map) builder;
   final DeviceInfoPlugin deviceInfo = DeviceInfoPlugin();
 
   PhoneDependentContainer({Key key, @required this.builder}) : super(key: key);
+  Map<String, dynamic> _readAndroidBuildData(AndroidDeviceInfo build) {
+    return <String, dynamic>{
+      'version.securityPatch': build.version.securityPatch,
+      'version.sdkInt': build.version.sdkInt,
+      'version.release': build.version.release,
+      'version.previewSdkInt': build.version.previewSdkInt,
+      'version.incremental': build.version.incremental,
+      'version.codename': build.version.codename,
+      'version.baseOS': build.version.baseOS,
+      'board': build.board,
+      'bootloader': build.bootloader,
+      'brand': build.brand,
+      'device': build.device,
+      'display': build.display,
+      'fingerprint': build.fingerprint,
+      'hardware': build.hardware,
+      'host': build.host,
+      'id': build.id,
+      'manufacturer': build.manufacturer,
+      'model': build.model,
+      'product': build.product,
+      'supported32BitAbis': build.supported32BitAbis,
+      'supported64BitAbis': build.supported64BitAbis,
+      'supportedAbis': build.supportedAbis,
+      'tags': build.tags,
+      'type': build.type,
+      'isPhysicalDevice': build.isPhysicalDevice,
+      'androidId': build.androidId,
+      'systemFeatures': build.systemFeatures,
+    };
+  }
+
+  Map<String, dynamic> _readIosDeviceInfo(IosDeviceInfo data) {
+    return <String, dynamic>{
+      'name': data.name,
+      'systemName': data.systemName,
+      'systemVersion': data.systemVersion,
+      'model': data.model,
+      'localizedModel': data.localizedModel,
+      'identifierForVendor': data.identifierForVendor,
+      'isPhysicalDevice': data.isPhysicalDevice,
+      'utsname.sysname:': data.utsname.sysname,
+      'utsname.nodename:': data.utsname.nodename,
+      'utsname.release:': data.utsname.release,
+      'utsname.version:': data.utsname.version,
+      'utsname.machine:': data.utsname.machine,
+    };
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -115,6 +163,9 @@ class PhoneDependentContainer extends StatelessWidget {
                       context,
                       snapshot.data.model,
                       snapshot.data,
+                      _readAndroidBuildData(
+                        snapshot.data,
+                      ),
                     ),
                   ),
           ),
@@ -131,6 +182,9 @@ class PhoneDependentContainer extends StatelessWidget {
                       context,
                       snapshot.data.model,
                       snapshot.data,
+                      _readIosDeviceInfo(
+                        snapshot.data,
+                      ),
                     ),
                   ),
           ),


### PR DESCRIPTION
So I made a widget to deal with phone dependent situations, the builder parameter is a function that will give you a context, the device model, and all the corresponding device information. I was considering making two build parameters one for iOS and one for Android but I think that is unnecessary so far.